### PR TITLE
ENH: Backport ability to save auth state on user.

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -24,10 +24,13 @@ class TokenAPIHandler(APIHandler):
     def post(self):
         if self.authenticator is not None:
           data = self.get_json_body()
-          username = yield self.authenticator.authenticate(self, data)
-          if username is None:
+          authenticated = yield self.authenticator.authenticate(self, data)
+          if authenticated is None:
             raise web.HTTPError(403)
-          user = self.find_user(username)
+
+          if isinstance(authenticated, dict):
+              authenticated = authenticated.get('name')
+          user = self.find_user(authenticated)
           api_token = user.new_api_token()
           self.write(json.dumps({"Authentication":api_token}))
         else:


### PR DESCRIPTION
This feature was taken from upstream, with some minor modifications.

We will use `auth-state` to pass an authentication token along with `user_id` from QF.

PR for our custom authenticator to accept `auth-state`: https://github.com/quantopian/qfauth/pull/16